### PR TITLE
Add terminals' connections in the getLines request

### DIFF
--- a/src/main/java/com/powsybl/network/map/NetworkMapService.java
+++ b/src/main/java/com/powsybl/network/map/NetworkMapService.java
@@ -64,6 +64,8 @@ class NetworkMapService {
         LineMapData.LineMapDataBuilder builder = LineMapData.builder()
                 .name(line.getName())
                 .id(line.getId())
+                .isTerminal1Connected(terminal1.isConnected())
+                .isTerminal2Connected(terminal2.isConnected())
                 .voltageLevelId1(terminal1.getVoltageLevel().getId())
                 .voltageLevelId2(terminal2.getVoltageLevel().getId());
         if (!Double.isNaN(terminal1.getP())) {

--- a/src/main/java/com/powsybl/network/map/NetworkMapService.java
+++ b/src/main/java/com/powsybl/network/map/NetworkMapService.java
@@ -64,8 +64,8 @@ class NetworkMapService {
         LineMapData.LineMapDataBuilder builder = LineMapData.builder()
                 .name(line.getName())
                 .id(line.getId())
-                .isTerminal1Connected(terminal1.isConnected())
-                .isTerminal2Connected(terminal2.isConnected())
+                .terminal1Connected(terminal1.isConnected())
+                .terminal2Connected(terminal2.isConnected())
                 .voltageLevelId1(terminal1.getVoltageLevel().getId())
                 .voltageLevelId2(terminal2.getVoltageLevel().getId());
         if (!Double.isNaN(terminal1.getP())) {

--- a/src/main/java/com/powsybl/network/map/model/LineMapData.java
+++ b/src/main/java/com/powsybl/network/map/model/LineMapData.java
@@ -25,6 +25,10 @@ public class LineMapData {
 
     private String name;
 
+    private Boolean isTerminal1Connected;
+
+    private Boolean isTerminal2Connected;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer p1;
 

--- a/src/main/java/com/powsybl/network/map/model/LineMapData.java
+++ b/src/main/java/com/powsybl/network/map/model/LineMapData.java
@@ -25,9 +25,9 @@ public class LineMapData {
 
     private String name;
 
-    private Boolean isTerminal1Connected;
+    private Boolean terminal1Connected;
 
-    private Boolean isTerminal2Connected;
+    private Boolean terminal2Connected;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer p1;

--- a/src/test/resources/lines-map-data.json
+++ b/src/test/resources/lines-map-data.json
@@ -4,6 +4,8 @@
     "name": "NHV1_NHV2_1",
     "voltageLevelId1": "VLHV1",
     "voltageLevelId2": "VLHV2",
+    "isTerminal1Connected": true,
+    "isTerminal2Connected": true,
     "p1": 1,
     "q1": 2,
     "p2": 3,
@@ -13,6 +15,8 @@
     "id": "NHV1_NHV2_2",
     "name": "NHV1_NHV2_2",
     "voltageLevelId1": "VLHV1",
-    "voltageLevelId2": "VLHV2"
+    "voltageLevelId2": "VLHV2",
+    "isTerminal1Connected": true,
+    "isTerminal2Connected": true
   }
 ]

--- a/src/test/resources/lines-map-data.json
+++ b/src/test/resources/lines-map-data.json
@@ -4,8 +4,8 @@
     "name": "NHV1_NHV2_1",
     "voltageLevelId1": "VLHV1",
     "voltageLevelId2": "VLHV2",
-    "isTerminal1Connected": true,
-    "isTerminal2Connected": true,
+    "terminal1Connected": true,
+    "terminal2Connected": true,
     "p1": 1,
     "q1": 2,
     "p2": 3,
@@ -16,7 +16,7 @@
     "name": "NHV1_NHV2_2",
     "voltageLevelId1": "VLHV1",
     "voltageLevelId2": "VLHV2",
-    "isTerminal1Connected": true,
-    "isTerminal2Connected": true
+    "terminal1Connected": true,
+    "terminal2Connected": true
   }
 ]


### PR DESCRIPTION
Signed-off-by: HOMER Etienne <etiennehomer@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** This PR adds two parameters in the getLines request answer : isTerminal1Connected and isTerminal2Connected.

**What is the current behavior?** Terminals' connections are not given in the request answer.



**What is the new behavior (if this is a feature change)?** Terminals' connections are given to the client.

